### PR TITLE
Datetime Picker not created from datetime fields.

### DIFF
--- a/src/views/footer.twig
+++ b/src/views/footer.twig
@@ -16,7 +16,7 @@
     flatpickr('.crudDate', {
         dateFormat: 'Y-m-d'
     });
-    flatpickr('.crudDatetime', {
+    flatpickr('.crudDateTime', {
         dateFormat: 'Y-m-d H:i',
         enableTime: true,
         time_24hr: true


### PR DESCRIPTION
Fixing datetimepicker initialization. The css class name is crudDateTime but initialization was using the selector .crudDatetime.