### PR TITLE
Remove filters and listfields from description example

### DIFF
--- a/docs/manual/extendedfeatures.rst
+++ b/docs/manual/extendedfeatures.rst
@@ -23,8 +23,6 @@ description per field. In this case, the author of a book is more informative:
     book:
         label: Book
         table: book
-        listFields: [id, created_at, updated_at, author, title]
-        filter: [author, title]
         fields:
             author:
                 type: text

--- a/src/CRUDlex/EntityDefinition.php
+++ b/src/CRUDlex/EntityDefinition.php
@@ -96,6 +96,11 @@ class EntityDefinition {
     protected $initialSortAscending;
 
     /**
+     * Holds if the entity must be displayed grouped in the nav bar.
+     */
+    protected $navBarGroup;
+
+    /**
      * Gets the field names exluding the given ones.
      *
      * @param string[] $exclude
@@ -171,6 +176,7 @@ class EntityDefinition {
         $this->locale               = null;
         $this->initialSortField     = 'created_at';
         $this->initialSortAscending = true;
+        $this->navBarGroup          = 'main';
     }
 
     /**
@@ -556,6 +562,26 @@ class EntityDefinition {
      */
     public function isInitialSortAscending() {
         return $this->initialSortAscending;
+    }
+    
+    /**
+     * Gets the navigation bar group where the entity belongs
+     *
+     * @return string
+     * the navigation bar group where the entity belongs
+     */
+    public function getNavBarGroup() {
+        return $this->navBarGroup;
+    }
+
+    /**
+     * Sets the navigation bar group where the entity belongs
+     *
+     * @param string $navBarGroup
+     * the navigation bar group where the entity belongs
+     */
+    public function setNavBarGroup($navBarGroup) {
+        $this->navBarGroup = $navBarGroup;
     }
 
     /**

--- a/src/CRUDlex/ServiceProvider.php
+++ b/src/CRUDlex/ServiceProvider.php
@@ -156,7 +156,7 @@ class ServiceProvider implements ServiceProviderInterface, BootableProviderInter
             'childrenLabelFields',
             'pageSize',
             'initialSortField',
-            'initialSortAscending'
+            'initialSortAscending',
             'navBarGroup'
         ];
         foreach ($toConfigure as $field) {

--- a/src/CRUDlex/ServiceProvider.php
+++ b/src/CRUDlex/ServiceProvider.php
@@ -157,6 +157,7 @@ class ServiceProvider implements ServiceProviderInterface, BootableProviderInter
             'pageSize',
             'initialSortField',
             'initialSortAscending'
+            'navBarGroup'
         ];
         foreach ($toConfigure as $field) {
             if (array_key_exists($field, $crud)) {
@@ -303,6 +304,24 @@ class ServiceProvider implements ServiceProviderInterface, BootableProviderInter
      */
     public function getEntities() {
         return array_keys($this->datas);
+    }
+
+    /**
+     * Getter for the entitis fot the navigation bar.
+     *
+     * @return string[]
+     * a list of all available entity names with theirs group
+     */
+    public function getEntitiesNavBar() {
+      foreach ($this->datas as $entity => $data) {
+        $navBarGroup = $data->getDefinition()->getNavBarGroup();
+        if ($navBarGroup !== 'main'){
+          $result[$navBarGroup][] = $entity;
+        }else{
+          $result[$entity] = 'main';
+        }
+      }
+        return $result;
     }
 
     /**

--- a/src/views/layout.twig
+++ b/src/views/layout.twig
@@ -73,8 +73,20 @@
                 <div class="container">
                     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                         <ul class="nav navbar-nav navbar-right">
-                            {% for entity in app.crud.getEntities() %}
-                                <li {% if crudEntity == entity %} class="active" {% endif%}><a href="{{ app.url_generator.generate('crudList', {'entity': entity}) }}">{{ app.crud.getData(entity).getDefinition().getLabel() }}</a></li>
+                            {% for entity, navBarGroup in app.crud.getEntitiesNavBar() %}
+                                {% if navBarGroup == 'main' %}
+                                    <li {% if crudEntity == entity %} class="active" {% endif%}><a href="{{ app.url_generator.generate('crudList', {'entity': entity}) }}">{{ app.crud.getData(entity).getDefinition().getLabel() }}</a></li>
+                                {% else %}
+                                  <li class="dropdown {% if crudEntity in navBarGroup %} active {% endif%}" >
+                                    <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ entity }}
+                                    <span class="caret"></span></a>
+                                    <ul class="dropdown-menu">
+                                      {% for subentity in navBarGroup %}
+                                          <li {% if crudEntity == subentity %} class="active" {% endif%}><a href="{{ app.url_generator.generate('crudList', {'entity': subentity}) }}">{{ app.crud.getData(subentity).getDefinition().getLabel() }}</a></li>
+                                      {% endfor %}
+                                    </ul>
+                                  </li>
+                                {% endif %}
                             {% endfor %}
                         </ul>
                     </div>


### PR DESCRIPTION
In the description feature example (first feature explained in Extended Features) are also other features that are explained later. At first sight is confusing to concentrate in the new feature example because the other two are above the new one, so it forces to read again the text.