### PR TITLE
Add attribute hideId for type=reference|many

### DIFF
--- a/docs/manual/crudyamlreference.rst
+++ b/docs/manual/crudyamlreference.rst
@@ -79,6 +79,8 @@ required, along with the default value or behaviour.
             thisField: library
             # the column of the cross table pointing to the related entity
             thatField: book
+            # if set to true, the reference will be displayed without its id
+            hideId : false
         homepage:
           # this field is a text represented as URL in the UI
           type: url
@@ -119,6 +121,8 @@ required, along with the default value or behaviour.
             # what field to take from the related entity to visualize it, defaults to the id
             # if not given
             nameField: name
+            # if set to true, the reference will be displayed without its id
+            hideId : false
         price:
           # this field is a floating point number
           type: float

--- a/docs/manual/datatypes.rst
+++ b/docs/manual/datatypes.rst
@@ -204,6 +204,7 @@ Reference
     reference:
       nameField: otherName
       entity: otherEntity
+      hideId: false
 
 This is the 1-side of a one-to-many relation. Related MySQL-type:
 
@@ -216,6 +217,8 @@ the referenced *entity*.
 
 The *nameField* is optional. If it is not given, only the id of the referenced
 *entity* is shown.
+
+The optional parameter *hideId* allows to display the reference without its id, if set to *true*.
 
 Think about a book in a library. The library is stored in the table "library" and
 has a field "name". A book belongs to a library, so it has an integer field
@@ -337,6 +340,7 @@ Many
             nameField: title
             thisField: library
             thatField: book
+            hideId: false
 
 A many-to-many relation. For MySQL, the field key is the name of the cross table.
 So the sample above translates to this structure:
@@ -362,6 +366,7 @@ The fields of the many key have the following meaning:
   many field
 * **thatField**: the field of the cross table referencing the other entity
   named with the entity field of the many key
+* **hideId** (optional) allows to display the reference without its id, if set to *true*.
 
 Think about a library having many books and a book being in many libraries.
 The library is stored in the table "library" and has a field "name". Here is

--- a/src/definitionSchema.yml
+++ b/src/definitionSchema.yml
@@ -228,6 +228,9 @@ root:
                       entity:
                         _type: text
                         _required: true
+                      hideId:
+                        _type: boolean
+                        _required: false
               11:
                 _type: array
                 _ignore_extra_keys: true
@@ -295,6 +298,10 @@ root:
                       thatField:
                         _type: text
                         _required: true
+                      hideId:
+                        _type: boolean
+                        _required: false
+
               14:
                 _type: array
                 _ignore_extra_keys: true

--- a/src/definitionSchema.yml
+++ b/src/definitionSchema.yml
@@ -230,7 +230,6 @@ root:
                         _required: true
                       hideId:
                         _type: boolean
-                        _required: false
               11:
                 _type: array
                 _ignore_extra_keys: true
@@ -300,7 +299,6 @@ root:
                         _required: true
                       hideId:
                         _type: boolean
-                        _required: false
 
               14:
                 _type: array

--- a/src/views/renderField.twig
+++ b/src/views/renderField.twig
@@ -17,11 +17,13 @@
 
 {% elseif type == 'reference' and entity.get(field) %}
     {% set reference = entity.get(field) %}
+    {% set hideId = definition.getSubTypeField(field, type, 'hideId') %}
+    {% set noName = 'name' not in reference|keys %}
     {% if reference is iterable %}
         <a href="{{ app.url_generator.generate('crudShow', {'entity': definition.getSubTypeField(field, 'reference', 'entity'), 'id': reference['id']}) }}" type="button" class="btn btn-default btn-xs btn-success">
-            {{ reference['id'] }}
-            {% if 'name' in reference|keys %}
-                : {{ reference['name'] }}
+            {% if noName %}      {{ reference['id'] }}
+            {% elseif hideId %}  {{ reference['name'] }}
+            {% else %}           {{ reference['id'] }} :  {{ reference['name'] }}
             {% endif %}
         </a>
     {% else %}
@@ -31,10 +33,12 @@
 {% elseif type == 'many' %}
     {% set many = entity.get(field) %}
     {% for reference in many  %}
+        {% set hideId = definition.getSubTypeField(field, type, 'hideId') %}
+        {% set noName = 'name' not in reference|keys %}
         <a href="{{ app.url_generator.generate('crudShow', {'entity': definition.getSubTypeField(field, 'many', 'entity'), 'id': reference['id']}) }}" type="button" class="btn btn-default btn-xs btn-success">
-            {{ reference['id'] }}
-            {% if 'name' in reference|keys %}
-                : {{ reference['name'] }}
+            {% if noName %}      {{ reference['id'] }}
+            {% elseif hideId %}  {{ reference['name'] }}
+            {% else %}           {{ reference['id'] }} :  {{ reference['name'] }}
             {% endif %}
         </a>
     {% endfor %}

--- a/src/views/renderField.twig
+++ b/src/views/renderField.twig
@@ -21,9 +21,12 @@
     {% set noName = 'name' not in reference|keys %}
     {% if reference is iterable %}
         <a href="{{ app.url_generator.generate('crudShow', {'entity': definition.getSubTypeField(field, 'reference', 'entity'), 'id': reference['id']}) }}" type="button" class="btn btn-default btn-xs btn-success">
-            {% if noName %}      {{ reference['id'] }}
-            {% elseif hideId %}  {{ reference['name'] }}
-            {% else %}           {{ reference['id'] }} :  {{ reference['name'] }}
+            {% if noName %}
+                {{ reference['id'] }}
+            {% elseif hideId %}
+                {{ reference['name'] }}
+            {% else %}
+                {{ reference['id'] }} :  {{ reference['name'] }}
             {% endif %}
         </a>
     {% else %}
@@ -36,9 +39,12 @@
         {% set hideId = definition.getSubTypeField(field, type, 'hideId') %}
         {% set noName = 'name' not in reference|keys %}
         <a href="{{ app.url_generator.generate('crudShow', {'entity': definition.getSubTypeField(field, 'many', 'entity'), 'id': reference['id']}) }}" type="button" class="btn btn-default btn-xs btn-success">
-            {% if noName %}      {{ reference['id'] }}
-            {% elseif hideId %}  {{ reference['name'] }}
-            {% else %}           {{ reference['id'] }} :  {{ reference['name'] }}
+            {% if noName %}
+                {{ reference['id'] }}
+            {% elseif hideId %}
+                {{ reference['name'] }}
+            {% else %}
+                {{ reference['id'] }} :  {{ reference['name'] }}
             {% endif %}
         </a>
     {% endfor %}

--- a/tests/CRUDlexTests/EntityDefinitionTest.php
+++ b/tests/CRUDlexTests/EntityDefinitionTest.php
@@ -18,8 +18,10 @@ use CRUDlex\EntityDefinition;
 
 class EntityDefinitionTest extends \PHPUnit_Framework_TestCase {
 
+    /** @var $definition EntityDefinition */
     protected $definition;
 
+    /** @var $definitionLibrary EntityDefinition */
     protected $definitionLibrary;
 
     protected function setUp() {
@@ -276,6 +278,15 @@ class EntityDefinitionTest extends \PHPUnit_Framework_TestCase {
         $read = $this->definitionLibrary->getSubTypeField('libraryBook', 'many', 'entity');
         $expected = 'book';
         $this->assertSame($expected, $read);
+
+        $read = $this->definitionLibrary->getSubTypeField('libraryBook', 'many', 'hideId');
+        $this->assertSame(true, $read);
+
+        $read = $this->definition->getSubTypeField('library', 'reference', 'hideId');
+        $this->assertSame(true, $read);
+
+        $read = $this->definitionLibrary->getSubTypeField('secondLibrary', 'reference', 'hideId');
+        $this->assertSame(null, $read);
 
         $read = $this->definitionLibrary->getSubTypeField('name', 'many', 'entity');
         $this->assertNull($read);

--- a/tests/crud.yml
+++ b/tests/crud.yml
@@ -36,6 +36,7 @@ library:
         nameField: title
         thisField: library
         thatField: book
+        hideId: true
 
 book:
   label: Book
@@ -67,6 +68,7 @@ book:
       reference:
         nameField: name
         entity: library
+        hideId: true
       required: true
     secondLibrary:
       type: reference


### PR DESCRIPTION
On a project that I worked on with my co-workers it made sense to display a reference or list of many references as tags 

This PR add an option to crud.yml that backports this change

Normal behavior:

![image](https://cloud.githubusercontent.com/assets/459464/24714110/da5e87d8-1a27-11e7-975a-0f79681ffb79.png)

With `hideId: true`

![image](https://cloud.githubusercontent.com/assets/459464/24714122/e41a1e68-1a27-11e7-88b8-0e891ff7d247.png)
