### PR TITLE
Group entities in the navigation Bar

### DIFF
--- a/docs/manual/crudyamlreference.rst
+++ b/docs/manual/crudyamlreference.rst
@@ -31,6 +31,10 @@ required, along with the default value or behaviour.
       # whether the list view is initially ascending (true) or descending (false)
       # sorted, defaults to true
       initialSortAscending: false
+      # This will create a top level item in the navigation bar called "learning"
+      # and put the library entity in a dropdown below the option. Defaults to
+      # 'main' (The entity will be in the top level of the navigation bar)
+      navBarGroup: learning
       # the displayed fields on the list view, defaults to id, created_at, updated_at,
       # and all given ones
       listFields: [id, created_at, updated_at, name, type, opening, isOpenOnSundays]

--- a/docs/manual/extendedfeatures.rst
+++ b/docs/manual/extendedfeatures.rst
@@ -23,8 +23,6 @@ description per field. In this case, the author of a book is more informative:
     book:
         label: Book
         table: book
-        listFields: [id, created_at, updated_at, author, title]
-        filter: [author, title]
         fields:
             author:
                 type: text

--- a/docs/manual/extendedfeatures.rst
+++ b/docs/manual/extendedfeatures.rst
@@ -138,6 +138,40 @@ Currently, the listview contains all entries on the pages. Often, it is desirabl
                 type: integer
                 label: Pages
 
+------------------------------------
+Group entities in the Navigation Bar
+------------------------------------
+
+Each entity represents and option in the navigation bar at the top. If there are
+too many entities or want to group based on relations between the entities, you
+can add a “navBarGroup” option. In this case we group library and books under
+“Learning Resources”:
+
+.. code-block:: yaml
+
+    library:
+        label: Library
+        table: library
+        navBarGroup: Learning Resources
+        fields:
+            name:
+                type: text
+                label: Name
+    book:
+        label: Book
+        table: book
+        navBarGroup: Learning Resources
+        fields:
+            author:
+                type: text
+                label: Author
+            title:
+                type: text
+                label: Title
+            pages:
+                type: integer
+                label: Pages
+
 ----
 I18n
 ----

--- a/src/CRUDlex/EntityDefinition.php
+++ b/src/CRUDlex/EntityDefinition.php
@@ -96,6 +96,11 @@ class EntityDefinition {
     protected $initialSortAscending;
 
     /**
+     * Holds if the entity must be displayed grouped in the nav bar.
+     */
+    protected $navBarGroup;
+
+    /**
      * Gets the field names exluding the given ones.
      *
      * @param string[] $exclude
@@ -171,6 +176,7 @@ class EntityDefinition {
         $this->locale               = null;
         $this->initialSortField     = 'created_at';
         $this->initialSortAscending = true;
+        $this->navBarGroup          = 'main';
     }
 
     /**
@@ -556,6 +562,26 @@ class EntityDefinition {
      */
     public function isInitialSortAscending() {
         return $this->initialSortAscending;
+    }
+
+    /**
+     * Gets the navigation bar group where the entity belongs.
+     *
+     * @return string
+     * the navigation bar group where the entity belongs
+     */
+    public function getNavBarGroup() {
+        return $this->navBarGroup;
+    }
+
+    /**
+     * Sets the navigation bar group where the entity belongs.
+     *
+     * @param string $navBarGroup
+     * the navigation bar group where the entity belongs
+     */
+    public function setNavBarGroup($navBarGroup) {
+        $this->navBarGroup = $navBarGroup;
     }
 
     /**

--- a/src/CRUDlex/ServiceProvider.php
+++ b/src/CRUDlex/ServiceProvider.php
@@ -129,7 +129,8 @@ class ServiceProvider implements ServiceProviderInterface, BootableProviderInter
             'childrenLabelFields',
             'pageSize',
             'initialSortField',
-            'initialSortAscending'
+            'initialSortAscending',
+            'navBarGroup'
         ];
         foreach ($toConfigure as $field) {
             if (array_key_exists($field, $crud)) {
@@ -280,6 +281,24 @@ class ServiceProvider implements ServiceProviderInterface, BootableProviderInter
      */
     public function getEntities() {
         return array_keys($this->datas);
+    }
+
+    /**
+     * Getter for the entities for the navigation bar.
+     *
+     * @return string[]
+     * a list of all available entity names with their group
+     */
+    public function getEntitiesNavBar() {
+        foreach ($this->datas as $entity => $data) {
+            $navBarGroup = $data->getDefinition()->getNavBarGroup();
+            if ($navBarGroup !== 'main'){
+                $result[$navBarGroup][] = $entity;
+            }else{
+                $result[$entity] = 'main';
+            }
+        }
+        return $result;
     }
 
     /**

--- a/src/definitionSchema.yml
+++ b/src/definitionSchema.yml
@@ -40,6 +40,9 @@ root:
       initialSortAscending:
         _type: boolean
 
+      navBarGroup:
+        _type: text
+
       childrenLabelFields:
         _type: prototype
         _prototype:

--- a/src/views/layout.twig
+++ b/src/views/layout.twig
@@ -73,8 +73,20 @@
                 <div class="container">
                     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                         <ul class="nav navbar-nav navbar-right">
-                            {% for entity in app.crud.getEntities() %}
-                                <li {% if crudEntity == entity %} class="active" {% endif%}><a href="{{ app.url_generator.generate('crudList', {'entity': entity}) }}">{{ app.crud.getData(entity).getDefinition().getLabel() }}</a></li>
+                            {% for entity, navBarGroup in app.crud.getEntitiesNavBar() %}
+                                {% if navBarGroup == 'main' %}
+                                    <li {% if crudEntity == entity %} class="active" {% endif%}><a href="{{ app.url_generator.generate('crudList', {'entity': entity}) }}">{{ app.crud.getData(entity).getDefinition().getLabel() }}</a></li>
+                                {% else %}
+                                  <li class="dropdown {% if crudEntity in navBarGroup %} active {% endif%}" >
+                                    <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ entity }}
+                                    <span class="caret"></span></a>
+                                    <ul class="dropdown-menu">
+                                      {% for subentity in navBarGroup %}
+                                          <li {% if crudEntity == subentity %} class="active" {% endif%}><a href="{{ app.url_generator.generate('crudList', {'entity': subentity}) }}">{{ app.crud.getData(subentity).getDefinition().getLabel() }}</a></li>
+                                      {% endfor %}
+                                    </ul>
+                                  </li>
+                                {% endif %}
                             {% endfor %}
                         </ul>
                     </div>

--- a/tests/CRUDlexTests/EntityDefinitionTest.php
+++ b/tests/CRUDlexTests/EntityDefinitionTest.php
@@ -336,4 +336,14 @@ class EntityDefinitionTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($expected, $read);
     }
 
+    public function testGetSetNavBarGroup() {
+        $read = $this->definition->getNavBarGroup();
+        $expected = 'entities';
+        $this->assertSame($read, $expected);
+        $this->definition->setNavBarGroup('main');
+        $read = $this->definition->getNavBarGroup();
+        $expected = 'main';
+        $this->assertSame($read, $expected);
+    }
+
 }

--- a/tests/CRUDlexTests/ServiceProviderTest.php
+++ b/tests/CRUDlexTests/ServiceProviderTest.php
@@ -81,6 +81,16 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($read, $expected);
     }
 
+    public function testGetEntitiesNavBar() {
+        $crudServiceProvider = new ServiceProvider();
+        $app = new Application();
+        $crudServiceProvider->boot($app);
+        $crudServiceProvider->init($this->dataFactory, $this->crudFile, null, $this->fileProcessorMock, $app);
+        $expected = ['entities' => ['library', 'book']];
+        $read = $crudServiceProvider->getEntitiesNavBar();
+        $this->assertSame($read, $expected);
+    }
+
     public function testGetData() {
         $crudServiceProvider = new ServiceProvider();
         $app = new Application();

--- a/tests/crud.yml
+++ b/tests/crud.yml
@@ -8,6 +8,7 @@ library:
   pageSize: 10
   initialSortField: name
   initialSortAscending: false
+  navBarGroup: entities
   fields:
     name:
       type: text
@@ -44,6 +45,7 @@ book:
   table: book
   listFields: [author, title, library]
   filter: [author, title, library]
+  navBarGroup: entities
   fields:
     title:
       type: text


### PR DESCRIPTION
Hi

The idea is to allow to group multiple entities into one option of the menu, this is helpful when there are too many entities or want to group based on relation. There is a example of the result:

<img width="884" alt="navbargroup example" src="https://cloud.githubusercontent.com/assets/1862981/25086742/f99617a6-2337-11e7-843c-2986033d30e2.png">
